### PR TITLE
Add bullet absorber system

### DIFF
--- a/Content.Shared/Weapons/Ranged/Components/BulletAbsorberComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/BulletAbsorberComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Weapons.Ranged.Components;
+
+/// <summary>
+/// When equipped, this item allows the user to absorb incoming bullets instead of being hit.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class BulletAbsorberComponent : Component
+{
+}

--- a/Content.Shared/Weapons/Ranged/Components/BulletAbsorberUserComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/BulletAbsorberUserComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Weapons.Ranged.Components;
+
+/// <summary>
+/// Added to a user while they are holding a bullet absorber so that bullet events can be routed to them.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class BulletAbsorberUserComponent : Component
+{
+}

--- a/Content.Shared/Weapons/Ranged/Systems/BulletAbsorberSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/BulletAbsorberSystem.cs
@@ -1,0 +1,65 @@
+using Content.Shared.Inventory;
+using Content.Shared.Inventory.Events;
+using Content.Shared.Projectiles;
+using Content.Shared.Weapons.Ranged.Events;
+using Content.Shared.Weapons.Ranged.Components;
+using System.Numerics;
+
+namespace Content.Shared.Weapons.Ranged.Systems;
+
+/// <summary>
+/// Handles absorbing projectiles and hitscan shots for users wielding a <see cref="BulletAbsorberComponent"/>.
+/// </summary>
+public sealed class BulletAbsorberSystem : EntitySystem
+{
+    [Dependency] private readonly InventorySystem _inventory = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BulletAbsorberComponent, GotEquippedHandEvent>(OnEquippedHand);
+        SubscribeLocalEvent<BulletAbsorberComponent, GotUnequippedHandEvent>(OnUnequippedHand);
+
+        SubscribeLocalEvent<BulletAbsorberUserComponent, ProjectileReflectAttemptEvent>(OnProjectile);
+        SubscribeLocalEvent<BulletAbsorberUserComponent, HitScanReflectAttemptEvent>(OnHitscan);
+    }
+
+    private void OnEquippedHand(EntityUid uid, BulletAbsorberComponent component, GotEquippedHandEvent args)
+    {
+        EnsureComp<BulletAbsorberUserComponent>(args.User);
+    }
+
+    private void OnUnequippedHand(EntityUid uid, BulletAbsorberComponent component, GotUnequippedHandEvent args)
+    {
+        RefreshUser(args.User);
+    }
+
+    private void RefreshUser(EntityUid user)
+    {
+        foreach (var ent in _inventory.GetHandOrInventoryEntities(user, SlotFlags.HANDS))
+        {
+            if (HasComp<BulletAbsorberComponent>(ent))
+            {
+                EnsureComp<BulletAbsorberUserComponent>(user);
+                return;
+            }
+        }
+
+        RemCompDeferred<BulletAbsorberUserComponent>(user);
+    }
+
+    private void OnProjectile(EntityUid uid, BulletAbsorberUserComponent component, ref ProjectileReflectAttemptEvent args)
+    {
+        // Delete the projectile and prevent it from damaging the user.
+        QueueDel(args.ProjUid);
+        args.Cancelled = true;
+    }
+
+    private void OnHitscan(EntityUid uid, BulletAbsorberUserComponent component, ref HitScanReflectAttemptEvent args)
+    {
+        // Absorb the hitscan by marking it as reflected with no direction.
+        args.Direction = Vector2.Zero;
+        args.Reflected = true;
+    }
+}


### PR DESCRIPTION
## Summary
- add `BulletAbsorberComponent` and `BulletAbsorberUserComponent`
- add `BulletAbsorberSystem` that removes projectiles and absorbs hitscan shots when the user is wielding the absorber

## Testing
- `dotnet build` *(fails: required SDK 9.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6861cce8a034832e952d4fb1c108ac90